### PR TITLE
add git-init prompt

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -96,6 +96,12 @@ module.exports = yeoman.generators.Base.extend({
 
   install: function () {
     this.installDependencies({ bower: false })
+
+    if (this.props.gitinit) {
+      this.spawnCommand("git", ["init"]);
+      this.spawnCommand("git", ["add", "--all"]);
+      this.spawnCommand('git', ["commit", "-m", "'initial commit, via generator-fly 🚀'"]);
+    }
   }
 })
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -51,6 +51,13 @@ module.exports = yeoman.generators.Base.extend({
         message: "Do you need a CHANGELOG file?",
         store: true,
         default: true
+      },
+      {
+        type: "confirm",
+        name: "gitinit",
+        message: "Initialize a Git repository?",
+        store: true,
+        default: true
       }
     ],
       function (props) {


### PR DESCRIPTION
simple Y/n confirm field

If yes, initializes a git repo, adds all generated/template files, and commits first message:
> initial commit, via generator-fly 🚀

#marketing

if accepted, closes #10 